### PR TITLE
Change specVersion

### DIFF
--- a/generators/app/templates/ui5-dist.yaml
+++ b/generators/app/templates/ui5-dist.yaml
@@ -1,4 +1,4 @@
-specVersion: "2.0"
+specVersion: "2.6"
 metadata:
   name: <%= appId %>
 type: application

--- a/generators/app/templates/ui5.yaml
+++ b/generators/app/templates/ui5.yaml
@@ -1,4 +1,4 @@
-specVersion: "2.0"
+specVersion: "2.6"
 metadata:
   name: <%= appId %>
 type: application


### PR DESCRIPTION
The app template has the dependency to ui5 cli 2.14.10 (package.json)
"@ui5/cli": "^2.14.10",

From the ui5 cli doc (https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions)
cli v2.14.0+ supports specVersion 2.6

New apps should benefit from the features latest ui5 cli releases offers, therefore why not increase the specVersion in the template?