### PR TITLE
Reference types via "typeRoots"

### DIFF
--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -4,8 +4,9 @@
     "noEmit": true,
     "checkJs": true,
     "allowJs": true,
-    "types": [
-        "<%= tstypes %>"
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules/<%= tstypes %>"
     ]
   }
 }


### PR DESCRIPTION
See https://github.com/ui5-community/generator-ui5-ts-app-fcl/issues/5#issuecomment-1200994227 and https://sap.github.io/ui5-typescript/known-issues.html#ts2688-cannot-find-type-definition-file-for-node_modules