### PR TITLE
feat: add ui5 middleware code coverage

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -131,6 +131,13 @@ export default class extends Generator {
 			} else {
 				this.config.set("defaultTheme", "sap_fiori_3");
 			}
+
+			// set qunit coverage file
+			if (semver.gte(props.frameworkVersion, "1.113.0")) {
+				this.config.set("qunitCoverageFile", `qunit-coverage-istanbul.js`);
+			} else {
+				this.config.set("qunitCoverageFile", `qunit-coverage.js`);
+			}
 		});
 	}
 

--- a/generators/app/templates/_.gitignore
+++ b/generators/app/templates/_.gitignore
@@ -14,3 +14,4 @@ node_modules/
 
 .DS_Store
 .env
+tmp/

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -20,6 +20,7 @@
 	},
 	"devDependencies": {
 		"@ui5/cli": "^3.6.1",
+		"@ui5/middleware-code-coverage": "^1.1.0",
 		"eslint": "^8.50.0",
 		"karma": "^6.4.2",
 		"karma-chrome-launcher": "^3.2.0",

--- a/generators/app/templates/ui5.yaml
+++ b/generators/app/templates/ui5.yaml
@@ -13,3 +13,5 @@ server:
   customMiddleware:
     - name: ui5-middleware-livereload
       afterMiddleware: compression
+    - name: "@ui5/middleware-code-coverage"
+      afterMiddleware: compression

--- a/generators/app/templates/webapp/test/integration/opaTests.qunit.html
+++ b/generators/app/templates/webapp/test/integration/opaTests.qunit.html
@@ -22,6 +22,7 @@
 		<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css" />
 		<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
 		<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
+		<script src="../../resources/sap/ui/qunit/<%= qunitCoverageFile %>" data-sap-ui-cover-only="<%= appURI %>/" data-sap-ui-cover-never="<%= appURI %>/test/"></script>
 	</head>
 	<body>
 		<div id="qunit"></div>

--- a/generators/app/templates/webapp/test/unit/unitTests.qunit.html
+++ b/generators/app/templates/webapp/test/unit/unitTests.qunit.html
@@ -19,7 +19,7 @@
 		<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css" />
 		<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
 		<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
-		<script src="../../resources/sap/ui/qunit/qunit-coverage.js"></script>
+		<script src="../../resources/sap/ui/qunit/<%= qunitCoverageFile %>" data-sap-ui-cover-only="<%= appURI %>/" data-sap-ui-cover-never="<%= appURI %>/test/"></script>
 		<script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
 		<script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
 	</head>


### PR DESCRIPTION
Allows client side code coverage generation for ES6+ code powered by https://github.com/SAP/ui5-tooling-extensions/tree/main/packages/middleware-code-coverage.

Projects generated for UI5 versions before 1.113.0 will stick to old "Blanket.js" based code coverage determination limited to ES5 language specification.

JIRA: CPOUI5FOUNDATION-721