### PR TITLE
feat: Use Test Starter

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -9,8 +9,12 @@ import { glob } from "glob";
 import packageJson from "package-json";
 import semver from "semver";
 import upath from "upath";
+import path from "path";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
+
+const webappTestDir = path.normalize("webapp/test/");
+const webappTestDir_lt1_124 = path.normalize("webapp/test-lt1_124/");
 
 export default class extends Generator {
 	static displayName = "Create a new UI5 application";
@@ -143,6 +147,7 @@ export default class extends Generator {
 			// version parameters
 			this.config.set("gte1_98_0", semver.gte(props.frameworkVersion, "1.98.0"));
 			this.config.set("gte1_104_0", semver.gte(props.frameworkVersion, "1.104.0"));
+			this.config.set("lt1_124_0", semver.lt(props.frameworkVersion, "1.124.0"));
 		});
 	}
 
@@ -156,8 +161,21 @@ export default class extends Generator {
 				nodir: true
 			})
 			.forEach((file) => {
+				let sTargetFile = file;
+
+				// Use different "test" folder for older versions
+				if (file.startsWith(webappTestDir_lt1_124)) {
+					if (this.config.get("lt1_124_0")) {
+						sTargetFile = file.replace(webappTestDir_lt1_124, webappTestDir);
+					} else {
+						return;
+					}
+				} else if (file.startsWith(webappTestDir) && this.config.get("lt1_124_0")) {
+					return;
+				}
+
 				const sOrigin = this.templatePath(file);
-				let sTarget = this.destinationPath(file.replace(/^_/, "").replace(/\/_/, "/"));
+				let sTarget = this.destinationPath(sTargetFile.replace(/^_/, "").replace(/\/_/, "/"));
 
 				this.fs.copyTpl(sOrigin, sTarget, oConfig);
 			});

--- a/generators/app/templates/webapp/test-lt1_124/integration/HelloJourney.js
+++ b/generators/app/templates/webapp/test-lt1_124/integration/HelloJourney.js
@@ -1,0 +1,49 @@
+/* global QUnit */
+sap.ui.define(["sap/ui/test/opaQunit", "./pages/Main"], function (opaTest) {
+	"use strict";
+
+	QUnit.module("Sample Hello Journey");
+
+	opaTest("Should open the Hello dialog", function (Given, When, Then) {
+		// Arrangements
+		Given.iStartMyUIComponent({
+			componentConfig: {
+				name: "<%= appId %>"
+			}
+		});
+
+		// Actions
+		When.onTheMainPage.iPressTheSayHelloButton();
+
+		// Assertions
+		Then.onTheMainPage.iShouldSeeTheHelloDialog();
+
+		// Actions
+		When.onTheMainPage.iPressTheOkButtonInTheDialog();
+
+		// Assertions
+		Then.onTheMainPage.iShouldNotSeeTheHelloDialog();
+
+		// Cleanup
+		Then.iTeardownMyApp();
+	});
+
+	opaTest("Should close the Hello dialog", function (Given, When, Then) {
+		// Arrangements
+		Given.iStartMyUIComponent({
+			componentConfig: {
+				name: "<%= appId %>"
+			}
+		});
+
+		// Actions
+		When.onTheMainPage.iPressTheSayHelloButton();
+		When.onTheMainPage.iPressTheOkButtonInTheDialog();
+
+		// Assertions
+		Then.onTheMainPage.iShouldNotSeeTheHelloDialog();
+
+		// Cleanup
+		Then.iTeardownMyApp();
+	});
+});

--- a/generators/app/templates/webapp/test-lt1_124/integration/opaTests.qunit.html
+++ b/generators/app/templates/webapp/test-lt1_124/integration/opaTests.qunit.html
@@ -1,27 +1,28 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate" />
 		<meta http-equiv="Pragma" content="no-cache" />
 		<meta http-equiv="expires" content="0" />
 		<meta charset="utf-8" />
-		<title>Unit tests for the UI5 Application: <%= namespace %></title>
+		<title>Integration tests for the UI5 Application: <%= namespace %></title>
 		<script
 			id="sap-ui-bootstrap"
 			src="../../resources/sap-ui-core.js"
+			data-sap-ui-theme="<%= defaultTheme %>"
 			data-sap-ui-resourceroots='{
 				"<%= appId %>": "../../",
-				"unit": "."
+				"integration": "."
 			}'
+			data-sap-ui-animation="false"
+			data-sap-ui-compatVersion="edge"
 			data-sap-ui-async="true"
-			data-sap-ui-oninit="module:unit/unitTests.qunit"
+			data-sap-ui-oninit="module:integration/opaTests.qunit"
 		></script>
 		<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css" />
 		<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
 		<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
 		<script src="../../resources/sap/ui/qunit/<%= qunitCoverageFile %>" data-sap-ui-cover-only="<%= appURI %>/" data-sap-ui-cover-never="<%= appURI %>/test/"></script>
-		<script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
-		<script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
 	</head>
 	<body>
 		<div id="qunit"></div>

--- a/generators/app/templates/webapp/test-lt1_124/integration/opaTests.qunit.js
+++ b/generators/app/templates/webapp/test-lt1_124/integration/opaTests.qunit.js
@@ -1,0 +1,11 @@
+/* global QUnit */
+// https://api.qunitjs.com/config/autostart/
+QUnit.config.autostart = false;
+
+sap.ui.getCore().attachInit(function () {
+	"use strict";
+
+	sap.ui.require(["integration/HelloJourney"], function () {
+		QUnit.start();
+	});
+});

--- a/generators/app/templates/webapp/test-lt1_124/integration/pages/Main.js
+++ b/generators/app/templates/webapp/test-lt1_124/integration/pages/Main.js
@@ -1,0 +1,53 @@
+sap.ui.define(["sap/ui/test/Opa5", "sap/ui/test/actions/Press"], function (Opa5, Press) {
+	"use strict";
+
+	Opa5.createPageObjects({
+		onTheMainPage: {
+			actions: {
+				iPressTheSayHelloButton: function () {
+					return this.waitFor({
+						id: "helloButton",
+						viewName: "<%= appId %>.view.Main",
+						actions: new Press(),
+						errorMessage: "Did not find the 'Say Hello With Dialog' button on the App view"
+					});
+				},
+
+				iPressTheOkButtonInTheDialog: function () {
+					return this.waitFor({
+						controlType: "sap.m.Button",
+						searchOpenDialogs: true,
+						viewName: "<%= appId %>.view.Main",
+						actions: new Press(),
+						errorMessage: "Did not find the 'OK' button in the Dialog"
+					});
+				}
+			},
+
+			assertions: {
+				iShouldSeeTheHelloDialog: function () {
+					return this.waitFor({
+						controlType: "sap.m.Dialog",
+						success: function () {
+							// we set the view busy, so we need to query the parent of the app
+							Opa5.assert.ok(true, "The dialog is open");
+						},
+						errorMessage: "Did not find the dialog control"
+					});
+				},
+
+				iShouldNotSeeTheHelloDialog: function () {
+					return this.waitFor({
+						controlType: "sap.m.App", // dummy, I just want a check function, where I can search the DOM. Probably there is a better way for a NEGATIVE test (NO dialog).
+						check: function () {
+							return document.querySelectorAll(".sapMDialog").length === 0;
+						},
+						success: function () {
+							Opa5.assert.ok(true, "No dialog is open");
+						}
+					});
+				}
+			}
+		}
+	});
+});

--- a/generators/app/templates/webapp/test-lt1_124/testsuite.qunit.html
+++ b/generators/app/templates/webapp/test-lt1_124/testsuite.qunit.html
@@ -6,13 +6,8 @@
 		<meta http-equiv="expires" content="0" />
 		<meta charset="utf-8" />
 		<title>QUnit test suite for the UI5 Application: <%= namespace %></title>
-		<script
-			src="../resources/sap/ui/test/starter/createSuite.js"
-			data-sap-ui-testsuite="test-resources/<%= appURI %>/testsuite.qunit"
-			data-sap-ui-resource-roots='{
-				"test-resources.<%= appId %>": "./"
-			}'
-		></script>
+		<script src="../resources/sap/ui/qunit/qunit-redirect.js"></script>
+		<script src="testsuite.qunit.js" data-sap-ui-testsuite></script>
 	</head>
 	<body></body>
 </html>

--- a/generators/app/templates/webapp/test-lt1_124/testsuite.qunit.js
+++ b/generators/app/templates/webapp/test-lt1_124/testsuite.qunit.js
@@ -1,0 +1,9 @@
+/* eslint-disable */
+window.suite = function () {
+	var suite = new parent.jsUnitTestSuite();
+	var aParts = location.pathname.match(/(.*\/)(?:[^/]+)/);
+	var sContextPath = aParts && aParts[1];
+	suite.addTestPage(sContextPath + "unit/unitTests.qunit.html");
+	suite.addTestPage(sContextPath + "integration/opaTests.qunit.html");
+	return suite;
+};

--- a/generators/app/templates/webapp/test-lt1_124/unit/controller/App.qunit.js
+++ b/generators/app/templates/webapp/test-lt1_124/unit/controller/App.qunit.js
@@ -1,0 +1,11 @@
+/* global QUnit */
+sap.ui.define(["<%= appURI %>/controller/Main.controller"], function (MainController) {
+	"use strict";
+
+	QUnit.module("Sample App controller test");
+
+	QUnit.test("The AppController class has a sayHello method", function (assert) {
+		// as a very basic test example just check the presence of the "sayHello" method
+		assert.strictEqual(typeof MainController.prototype.sayHello, "function");
+	});
+});

--- a/generators/app/templates/webapp/test-lt1_124/unit/unitTests.qunit.html
+++ b/generators/app/templates/webapp/test-lt1_124/unit/unitTests.qunit.html
@@ -1,28 +1,27 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate" />
 		<meta http-equiv="Pragma" content="no-cache" />
 		<meta http-equiv="expires" content="0" />
 		<meta charset="utf-8" />
-		<title>Integration tests for the UI5 Application: <%= namespace %></title>
+		<title>Unit tests for the UI5 Application: <%= namespace %></title>
 		<script
 			id="sap-ui-bootstrap"
 			src="../../resources/sap-ui-core.js"
-			data-sap-ui-theme="<%= defaultTheme %>"
 			data-sap-ui-resourceroots='{
 				"<%= appId %>": "../../",
-				"integration": "."
+				"unit": "."
 			}'
-			data-sap-ui-animation="false"
-			data-sap-ui-compatVersion="edge"
 			data-sap-ui-async="true"
-			data-sap-ui-oninit="module:integration/opaTests.qunit"
+			data-sap-ui-oninit="module:unit/unitTests.qunit"
 		></script>
 		<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css" />
 		<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
 		<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
 		<script src="../../resources/sap/ui/qunit/<%= qunitCoverageFile %>" data-sap-ui-cover-only="<%= appURI %>/" data-sap-ui-cover-never="<%= appURI %>/test/"></script>
+		<script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
+		<script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
 	</head>
 	<body>
 		<div id="qunit"></div>

--- a/generators/app/templates/webapp/test-lt1_124/unit/unitTests.qunit.js
+++ b/generators/app/templates/webapp/test-lt1_124/unit/unitTests.qunit.js
@@ -1,0 +1,12 @@
+/* global QUnit */
+
+// https://api.qunitjs.com/config/autostart/
+QUnit.config.autostart = false;
+
+sap.ui.getCore().attachInit(function () {
+	"use strict";
+
+	sap.ui.require(["unit/controller/App.qunit"], function () {
+		QUnit.start();
+	});
+});

--- a/generators/app/templates/webapp/test/Test.qunit.html
+++ b/generators/app/templates/webapp/test/Test.qunit.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<script
+			src="../resources/sap/ui/test/starter/runTest.js"
+			data-sap-ui-resource-roots='{
+			"test-resources.<%= appId %>": "./"
+		}'
+		></script>
+	</head>
+	<body class="sapUiBody">
+		<div id="qunit"></div>
+		<div id="qunit-fixture"></div>
+	</body>
+</html>

--- a/generators/app/templates/webapp/test/integration/opaTests.qunit.js
+++ b/generators/app/templates/webapp/test/integration/opaTests.qunit.js
@@ -1,11 +1,1 @@
-/* global QUnit */
-// https://api.qunitjs.com/config/autostart/
-QUnit.config.autostart = false;
-
-sap.ui.getCore().attachInit(function () {
-	"use strict";
-
-	sap.ui.require(["integration/HelloJourney"], function () {
-		QUnit.start();
-	});
-});
+sap.ui.define(["./HelloJourney"]);

--- a/generators/app/templates/webapp/test/testsuite.qunit.js
+++ b/generators/app/templates/webapp/test/testsuite.qunit.js
@@ -1,9 +1,37 @@
-/* eslint-disable */
-window.suite = function () {
-	var suite = new parent.jsUnitTestSuite();
-	var aParts = location.pathname.match(/(.*\/)(?:[^/]+)/);
-	var sContextPath = aParts && aParts[1];
-	suite.addTestPage(sContextPath + "unit/unitTests.qunit.html");
-	suite.addTestPage(sContextPath + "integration/opaTests.qunit.html");
-	return suite;
-};
+sap.ui.define(function () {
+	"use strict";
+
+	return {
+		name: "QUnit test suite for the UI5 Application: <%= namespace %>",
+		defaults: {
+			page: "ui5://test-resources/<%= appURI %>/Test.qunit.html?testsuite={suite}&test={name}",
+			qunit: {
+				version: 2
+			},
+			sinon: {
+				version: 1
+			},
+			ui5: {
+				language: "EN",
+				theme: "<%= defaultTheme %>"
+			},
+			coverage: {
+				only: "<%= appURI %>/",
+				never: "test-resources/<%= appURI %>/"
+			},
+			loader: {
+				paths: {
+					"<%= appURI %>": "../"
+				}
+			}
+		},
+		tests: {
+			"unit/unitTests": {
+				title: "Unit tests for <%= namespace %>"
+			},
+			"integration/opaTests": {
+				title: "Integration tests for <%= namespace %>"
+			}
+		}
+	};
+});

--- a/generators/app/templates/webapp/test/unit/unitTests.qunit.js
+++ b/generators/app/templates/webapp/test/unit/unitTests.qunit.js
@@ -1,12 +1,1 @@
-/* global QUnit */
-
-// https://api.qunitjs.com/config/autostart/
-QUnit.config.autostart = false;
-
-sap.ui.getCore().attachInit(function () {
-	"use strict";
-
-	sap.ui.require(["unit/controller/App.qunit"], function () {
-		QUnit.start();
-	});
-});
+sap.ui.define(["./controller/App.qunit"]);


### PR DESCRIPTION
This change introduces the test starter as a replacement for the traditional test suite + test page setup.

The feature is only available for application projects starting with UI5 1.124, so the existing test setup is kept for older projects.